### PR TITLE
feat: add CloudBees test results publishing action to blog workflow

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -59,12 +59,49 @@ jobs:
         with:
           path: apps/blog/dist
 
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Install dependencies
+        run: |
+          cd apps/blog
+          pnpm install
+
+      - name: Run tests
+        run: |
+          cd apps/blog
+          # Add your test command here when tests are implemented
+          # pnpm test || true
+
+      - name: Publish test results to Platform
+        uses: cloudbees-io-gha/publish-test-results@v2.0.1
+        with:
+          test-type: junit
+          results-path: test-results/**/*.xml
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, test]
     permissions:
       pages: write
       id-token: write

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -22,6 +22,7 @@ Log new agent activity for each commit: who did what and why.
 | 2025-12-11 | CTO | local | Phase 1 MVP wrap-up and deployment verification | Successfully launched blog at localhost:4321, verified all content renders correctly, established content creation workflow for future posts | Blog running on http://localhost:4321/ |
 | 2025-12-11 | CTO | feat/github-pages-deployment | Implemented GitHub Pages deployment and content automation | Configured Astro for GitHub Pages, created automated deployment workflow, set up content scheduling system with Tuesday/Friday publication schedule | .github/workflows/, docs/deployment.md, apps/blog/src/content/drafts/ |
 | 2026-01-07 | Auto | dc8444c | Enabled auto-merge for content automation PRs | Fixed workflow to automatically merge PRs after status checks pass; added auto-merge configuration to peter-evans/create-pull-request action | .github/workflows/content-automation.yml |
+| 2026-01-07 | Auto | feat/add-cloudbees-test-results-action | Added CloudBees test results publishing action to blog deployment workflow | Integrated CloudBees platform for test result tracking and analytics; added test job with publish-test-results action (v2.0.1) configured for JUnit format | .github/workflows/deploy-blog.yml |
 | YYYY-MM-DD | <agent> | <hash or #PR> | <summary> | <decision/assumption> | <issue/docs> |
 
 Guidance:


### PR DESCRIPTION
Added CloudBees test results publishing action to the blog deployment workflow.

## Changes
- Added new `test` job that runs after build
- Integrated CloudBees publish-test-results@v2.0.1 action
- Configured for JUnit format (can be updated when tests are implemented)
- Updated deploy job to depend on both build and test jobs

## Configuration
- test-type: junit
- results-path: test-results/**/*.xml

The workflow is ready to publish test results once tests are implemented.