### PR TITLE
feat: set up Vitest and Playwright testing frameworks

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -84,17 +84,51 @@ jobs:
           cd apps/blog
           pnpm install
 
-      - name: Run tests
+      - name: Run unit tests
         run: |
           cd apps/blog
-          # Add your test command here when tests are implemented
-          # pnpm test || true
+          mkdir -p test-results
+          pnpm test:unit || true
+
+      - name: Build for E2E tests
+        run: |
+          cd apps/blog
+          pnpm build
+
+      - name: Install Playwright browsers
+        run: |
+          cd apps/blog
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: |
+          cd apps/blog
+          pnpm test:e2e || true
+
+      - name: Check for test results
+        id: test-results-check
+        run: |
+          cd apps/blog
+          if [ -n "$(find test-results -name '*.xml' -type f 2>/dev/null)" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Found test result files:"
+            find test-results -name '*.xml' -type f
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "No test result files found - skipping CloudBees publish"
+          fi
 
       - name: Publish test results to Platform
+        if: steps.test-results-check.outputs.exists == 'true'
         uses: cloudbees-io-gha/publish-test-results@v2.0.1
         with:
           test-type: junit
-          results-path: test-results/**/*.xml
+          results-path: apps/blog/test-results/**/*.xml
+          # Prerequisites:
+          # 1. Set up CloudBees platform and GHA integration:
+          #    https://docs.cloudbees.com/docs/cloudbees-platform/latest/github-actions/intro
+          # 2. Tests generate JUnit XML reports in test-results/ directory
+          # 3. cloudbees-url is optional (defaults to https://api.cloudbees.io)
 
   deploy:
     environment:

--- a/apps/blog/e2e/about.spec.ts
+++ b/apps/blog/e2e/about.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('About Page', () => {
+  test('should navigate to about page', async ({ page }) => {
+    await page.goto('/about');
+    await expect(page).toHaveURL(/\/about/);
+  });
+
+  test('should display about page content', async ({ page }) => {
+    await page.goto('/about');
+    const content = page.locator('main, article');
+    await expect(content).toBeVisible();
+  });
+
+  test('should have page title', async ({ page }) => {
+    await page.goto('/about');
+    const title = page.locator('h1').first();
+    await expect(title).toBeVisible();
+  });
+});

--- a/apps/blog/e2e/blog.spec.ts
+++ b/apps/blog/e2e/blog.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Blog Pages', () => {
+  test('should navigate to blog index', async ({ page }) => {
+    await page.goto('/blog');
+    await expect(page).toHaveURL(/\/blog/);
+  });
+
+  test('should display blog posts list', async ({ page }) => {
+    await page.goto('/blog');
+    // Check for blog post links or articles
+    const blogPosts = page.locator('article, [class*="post"], a[href*="/blog/"]');
+    await expect(blogPosts.first()).toBeVisible();
+  });
+
+  test('should navigate to a blog post', async ({ page }) => {
+    await page.goto('/blog');
+    
+    // Find first blog post link
+    const firstPostLink = page.locator('a[href*="/blog/"]').first();
+    
+    if (await firstPostLink.count() > 0) {
+      const href = await firstPostLink.getAttribute('href');
+      await firstPostLink.click();
+      
+      // Should navigate to blog post page
+      await expect(page).toHaveURL(new RegExp(href || '/blog/'));
+      
+      // Should have article content
+      const article = page.locator('article, main');
+      await expect(article).toBeVisible();
+    }
+  });
+
+  test('should display blog post content', async ({ page }) => {
+    await page.goto('/blog');
+    
+    // Try to find and click first post
+    const firstPostLink = page.locator('a[href*="/blog/"]').first();
+    
+    if (await firstPostLink.count() > 0) {
+      await firstPostLink.click();
+      
+      // Check for post title
+      const title = page.locator('h1, h2').first();
+      await expect(title).toBeVisible();
+      
+      // Check for post content
+      const content = page.locator('article p, main p').first();
+      await expect(content).toBeVisible();
+    }
+  });
+});

--- a/apps/blog/e2e/homepage.spec.ts
+++ b/apps/blog/e2e/homepage.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test('should load successfully', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Fractals of Change/i);
+  });
+
+  test('should display site title', async ({ page }) => {
+    await page.goto('/');
+    const title = page.locator('h1').first();
+    await expect(title).toBeVisible();
+  });
+
+  test('should have navigation links', async ({ page }) => {
+    await page.goto('/');
+    const nav = page.locator('nav');
+    await expect(nav).toBeVisible();
+  });
+
+  test('should have blog posts section', async ({ page }) => {
+    await page.goto('/');
+    // Check for blog content or links
+    const blogSection = page.locator('main, article, [class*="blog"]').first();
+    await expect(blogSection).toBeVisible();
+  });
+});

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -7,7 +7,12 @@
     "build": "astro build",
     "build:gh-pages": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:unit": "vitest run --reporter=junit --outputFile=test-results/junit.xml",
+    "test:e2e": "playwright test --reporter=junit --output-dir=test-results",
+    "test:all": "pnpm test:unit && pnpm test:e2e"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",
@@ -15,5 +20,11 @@
     "@astrojs/sitemap": "^3.6.0",
     "astro": "^5.16.5",
     "sharp": "^0.34.3"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@vitest/ui": "^2.1.8",
+    "jsdom": "^25.0.1",
+    "vitest": "^2.1.8"
   }
 }

--- a/apps/blog/playwright.config.ts
+++ b/apps/blog/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ['html'],
+    ['junit', { outputFile: 'test-results/junit-e2e.xml' }],
+  ],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/apps/blog/src/consts.test.ts
+++ b/apps/blog/src/consts.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { SITE_TITLE, SITE_DESCRIPTION } from './consts';
+
+describe('consts', () => {
+  describe('SITE_TITLE', () => {
+    it('should be defined', () => {
+      expect(SITE_TITLE).toBeDefined();
+    });
+
+    it('should be "Fractals of Change"', () => {
+      expect(SITE_TITLE).toBe('Fractals of Change');
+    });
+
+    it('should be a non-empty string', () => {
+      expect(typeof SITE_TITLE).toBe('string');
+      expect(SITE_TITLE.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SITE_DESCRIPTION', () => {
+    it('should be defined', () => {
+      expect(SITE_DESCRIPTION).toBeDefined();
+    });
+
+    it('should be a non-empty string', () => {
+      expect(typeof SITE_DESCRIPTION).toBe('string');
+      expect(SITE_DESCRIPTION.length).toBeGreaterThan(0);
+    });
+
+    it('should contain relevant keywords', () => {
+      expect(SITE_DESCRIPTION.toLowerCase()).toContain('transformation');
+      expect(SITE_DESCRIPTION.toLowerCase()).toContain('organization');
+    });
+  });
+});

--- a/apps/blog/vitest.config.ts
+++ b/apps/blog/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+    outputFile: {
+      junit: 'test-results/junit.xml',
+    },
+    reporters: ['verbose', 'junit'],
+  },
+});

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -23,6 +23,7 @@ Log new agent activity for each commit: who did what and why.
 | 2025-12-11 | CTO | feat/github-pages-deployment | Implemented GitHub Pages deployment and content automation | Configured Astro for GitHub Pages, created automated deployment workflow, set up content scheduling system with Tuesday/Friday publication schedule | .github/workflows/, docs/deployment.md, apps/blog/src/content/drafts/ |
 | 2026-01-07 | Auto | dc8444c | Enabled auto-merge for content automation PRs | Fixed workflow to automatically merge PRs after status checks pass; added auto-merge configuration to peter-evans/create-pull-request action | .github/workflows/content-automation.yml |
 | 2026-01-07 | Auto | feat/add-cloudbees-test-results-action | Added CloudBees test results publishing action to blog deployment workflow | Integrated CloudBees platform for test result tracking and analytics; added test job with publish-test-results action (v2.0.1) configured for JUnit format | .github/workflows/deploy-blog.yml |
+| 2026-01-09 | Auto | feat/setup-testing-framework | Set up Vitest and Playwright testing frameworks with example tests | Implemented unit tests (Vitest) and E2E tests (Playwright) per tech stack requirements; configured JUnit XML output for CloudBees integration; added test scripts and updated workflow | apps/blog/package.json, vitest.config.ts, playwright.config.ts, e2e/, src/consts.test.ts, .github/workflows/deploy-blog.yml |
 | YYYY-MM-DD | <agent> | <hash or #PR> | <summary> | <decision/assumption> | <issue/docs> |
 
 Guidance:


### PR DESCRIPTION
## Changes
- Added Vitest for unit tests with JUnit XML output
- Added Playwright for E2E tests with JUnit XML output
- Created example unit tests for consts.ts
- Created example E2E tests for homepage, blog, and about pages
- Updated workflow to run tests and publish results to CloudBees
- Added test scripts to package.json
- Added test-results to .gitignore

## Test Scripts
- `pnpm test` - Run unit tests
- `pnpm test:watch` - Watch mode for unit tests
- `pnpm test:unit` - Run unit tests with JUnit XML output
- `pnpm test:e2e` - Run E2E tests with JUnit XML output
- `pnpm test:all` - Run all tests

## Next Steps
1. Install dependencies: `cd apps/blog && pnpm install`
2. Install Playwright browsers: `pnpm exec playwright install --with-deps chromium`
3. Run tests locally to verify setup

The workflow will automatically run tests and publish results to CloudBees once dependencies are installed.